### PR TITLE
Fix comment regex.

### DIFF
--- a/dotaKV.tmLanguage
+++ b/dotaKV.tmLanguage
@@ -22,7 +22,7 @@
 			<key>comment</key>
 			<string>Single line comment</string>
 			<key>match</key>
-			<string>(^|(\t|\s?)+)//.+</string>
+			<string>(^|(\t|\s?)+)//.*</string>
 			<key>name</key>
 			<string>comment.line.txt</string>
 		</dict>


### PR DESCRIPTION
Right now, `^\/\/$` is not parsed as a comment, although it's actually valid.
![image](https://cloud.githubusercontent.com/assets/1695469/8507516/fe474656-2246-11e5-9132-a38423268b33.png)