### PR TITLE
modify highlight for key & value

### DIFF
--- a/dotaKV.tmLanguage
+++ b/dotaKV.tmLanguage
@@ -30,7 +30,7 @@
 			<key>comment</key>
 			<string>Key color</string>
 			<key>match</key>
-			<string>^(\t|\s?)+"[a-zA-z\s]+"</string>
+			<string>^(\t|\s)*"[\w\s]+"</string>
 			<key>name</key>
 			<string>entity.name.tag.txt</string>
 		</dict>
@@ -38,7 +38,7 @@
 			<key>comment</key>
 			<string>Value color</string>
 			<key>match</key>
-			<string>(\t|\s)+"[a-zA-z0-9./|_\s]+"</string>
+			<string>(\t|\s)*"[\+\-\*\%\|\.\;\w\s\/]*"</string>
 			<key>name</key>
 			<string>string.quoted.txt</string>
 		</dict>


### PR DESCRIPTION
Excuse me for my __poor English__. 

## Preface
Thx for your convenience brought by "dota_kv".
This is a modified version by [ChouUn](https://github.com/ChouUn) (me). 
What I did is just to modify partial _regex_. 

## Why did I do it?
Because it couldn't work well when match a string, empty or containing special characters such as `+`, `-`, `;`, etc.
But I haven't learned regex before. Thus there may be a lot of bug, sorry.

## What did I fix?
For example:
"abc""123"
the former is red, but the latter is white.
"abc" ""
"abc" "abc/abc.vpcf"
"abc" "%radius + 25"
ditto.