### PR TITLE
Fix 2 bugs

### DIFF
--- a/dotaKV.tmLanguage
+++ b/dotaKV.tmLanguage
@@ -22,7 +22,7 @@
 			<key>comment</key>
 			<string>Single line comment</string>
 			<key>match</key>
-			<string>(^|(\t|\s?)+)//.*</string>
+			<string>(^|(\t|\s)*)//.*</string>
 			<key>name</key>
 			<string>comment.line.txt</string>
 		</dict>
@@ -38,7 +38,7 @@
 			<key>comment</key>
 			<string>Value color</string>
 			<key>match</key>
-			<string>(\t|\s)*"[\+\-\*\%\|\.\;\w\s\/]*"</string>
+			<string>(\t|\s)*"[\\\+\-\*\%\|\.\;\w\s\/]*"</string>
 			<key>name</key>
 			<string>string.quoted.txt</string>
 		</dict>


### PR DESCRIPTION
## Fix some of the conditions leading to breakdown
@MNoya The source of breakdown is a space between `Value color` and `single line comment`.
Now sublime seems to work. eg: `game\dota_addons\rpg_example\scripts\npc\npc_abilities_custom.txt`

## Fix highlight for value of file path
It support a value like `particles\units\heroes\hero_batrider.pcf`.
But it also has some bugs with `"Wearable1" { "ItemDef"	"6410"}`.