### PR TITLE
fixing +3k steps regex for comments

### DIFF
--- a/dotaKV.tmLanguage
+++ b/dotaKV.tmLanguage
@@ -22,7 +22,7 @@
 			<key>comment</key>
 			<string>Single line comment</string>
 			<key>match</key>
-			<string>(^|(\t|\s?)+)//.*</string>
+			<string>$//.*</string>
 			<key>name</key>
 			<string>comment.line.txt</string>
 		</dict>


### PR DESCRIPTION
Smallest nominator for single line comments in regex, takes exactly 9 steps, no matter what. the old one was super laggy.