### PR TITLE
Making Sublime Text Highlighting better and faster

### DIFF
--- a/dotaKV.YAML-tmLanguage
+++ b/dotaKV.YAML-tmLanguage
@@ -1,0 +1,26 @@
+# [PackageDev] target_format: plist, ext: tmLanguage
+---
+name: Dota 2 KV
+scopeName: source.kv
+fileTypes: [kv]
+uuid: 04c4bbdb-39e5-49da-be05-91103efa01e4
+
+patterns:
+- comment: A single line comment
+  name: comment.line.txt
+  match: '//.*'
+
+- comment: Ability Special Variable
+  name: variable.parameter
+  match: '%[^\s]*'
+
+- comment: A group of other sections or KV pairs
+  name: support.class
+  match: '^\s*(?!".*?"\s*".*?")".*?"'
+
+- comment: A key value pair
+  name: entity.name.tag.txt
+  match: '(".*?")\s*(".*?")'
+  captures:
+    '1': {name: entity.name.tag.txt}
+    '2': {name: string.quoted.txt}

--- a/dotaKV.tmLanguage
+++ b/dotaKV.tmLanguage
@@ -4,47 +4,60 @@
 <dict>
 	<key>fileTypes</key>
 	<array>
-		<string>txt</string>
+		<string>kv</string>
 	</array>
 	<key>name</key>
-	<string>Dota KV</string>
+	<string>Dota 2 KV</string>
 	<key>patterns</key>
 	<array>
 		<dict>
 			<key>comment</key>
-			<string>Ability Special Vars</string>
+			<string>A single line comment</string>
 			<key>match</key>
-			<string>%\w+</string>
-			<key>name</key>
-			<string>keyword.other.txt</string>
-		</dict>
-		<dict>
-			<key>comment</key>
-			<string>Single line comment</string>
-			<key>match</key>
-			<string>$//.*</string>
+			<string>//.*</string>
 			<key>name</key>
 			<string>comment.line.txt</string>
 		</dict>
 		<dict>
 			<key>comment</key>
-			<string>Key color</string>
+			<string>Ability Special Variable</string>
 			<key>match</key>
-			<string>^(\t|\s)*"[\w\s]+"</string>
+			<string>%[^\s]*</string>
 			<key>name</key>
-			<string>entity.name.tag.txt</string>
+			<string>variable.parameter</string>
 		</dict>
 		<dict>
 			<key>comment</key>
-			<string>Value color</string>
+			<string>A group of other sections or KV pairs</string>
 			<key>match</key>
-			<string>(\t|\s)*"[\+\-\*\%\|\.\;\w\s\/]*"</string>
+			<string>^\s*(?!".*?"\s*".*?")".*?"</string>
 			<key>name</key>
-			<string>string.quoted.txt</string>
+			<string>support.class</string>
+		</dict>
+		<dict>
+			<key>captures</key>
+			<dict>
+				<key>1</key>
+				<dict>
+					<key>name</key>
+					<string>entity.name.tag.txt</string>
+				</dict>
+				<key>2</key>
+				<dict>
+					<key>name</key>
+					<string>string.quoted.txt</string>
+				</dict>
+			</dict>
+			<key>comment</key>
+			<string>A key value pair</string>
+			<key>match</key>
+			<string>(".*?")\s*(?:(".*?"))</string>
+			<key>name</key>
+			<string>entity.name.tag.txt</string>
 		</dict>
 	</array>
 	<key>scopeName</key>
-	<string>source.txt</string>
+	<string>source.kv</string>
 	<key>uuid</key>
 	<string>04c4bbdb-39e5-49da-be05-91103efa01e4</string>
 </dict>


### PR DESCRIPTION
This pull request includes a lot of fixes to slow regex evaluation. In general this should be on average 5-10 times faster highlighting than before.

There is also another file added called ```dotaKV.YAML-tmLanguage``` which is meant for this package: https://github.com/SublimeText/AAAPackageDev - it adds a yaml variant for editing, which is way clearer than fiddling with xml (imho). The YAML variant will be supported soon­™ in ST3 aswell.